### PR TITLE
feat: Add template support for project index files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Automatically generate and maintain project index notes with customizable frontm
 - **Customizable Columns**: Configure which frontmatter fields appear as columns in the index table
 - **Organized Structure**: Project index files are created in a designated folder for better organization
 - **Table Management**: Automatically updates existing tables when regenerating the index
+- **Template Support**: Use custom templates for new project index files with variable substitution
 
 ## Installation
 
@@ -48,7 +49,7 @@ The generated project index will look like this:
 
 ```markdown
 ---
-type: project_index
+type: project_top
 project: MyProject
 ---
 
@@ -71,6 +72,24 @@ Access plugin settings via Settings → Project Indexer
 
 - **Project index folder**: Specify the folder where project index files will be created (default: `projects`)
 - **Frontmatter columns**: Comma-separated list of frontmatter fields to include as table columns (default: `status, priority`)
+
+### Template Settings
+
+- **Use template**: Enable to use custom templates when creating new project index files
+- **Template folder**: Select the folder containing your template files (optional)
+- **Default template**: Choose a default template file (leave empty to use default content)
+
+### Template Variables
+
+When using templates, the following variables are automatically replaced:
+
+- `{{title}}` - The project name
+- `{{date}}` - Current date (YYYY-MM-DD)
+- `{{time}}` - Current time (HH:mm)
+- `{{date:FORMAT}}` - Custom date format (e.g., `{{date:YYYY/MM/DD}}`)
+- `{{time:FORMAT}}` - Custom time format (e.g., `{{time:HH:mm:ss}}`)
+
+**Note**: The required frontmatter fields (`type: project_top` and `project: [project name]`) are automatically added regardless of template content.
 
 ## Development
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting, FuzzySuggestModal, TFile, TFolder } from 'obsidian';
 import ProjectIndexerPlugin from './main';
 
 export class ProjectIndexerSettingTab extends PluginSettingTab {
@@ -39,5 +39,144 @@ export class ProjectIndexerSettingTab extends PluginSettingTab {
 						.filter(col => col.length > 0);
 					await this.plugin.saveSettings();
 				}));
+
+		containerEl.createEl('h3', { text: 'Template Settings' });
+
+		new Setting(containerEl)
+			.setName('Use template')
+			.setDesc('Use a template when creating new project index files')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.useTemplate)
+				.onChange(async (value) => {
+					this.plugin.settings.useTemplate = value;
+					await this.plugin.saveSettings();
+					this.display(); // Refresh to show/hide template settings
+				}));
+
+		if (this.plugin.settings.useTemplate) {
+			new Setting(containerEl)
+				.setName('Template folder')
+				.setDesc('Folder containing template files (leave empty to search all folders)')
+				.addText(text => {
+					text
+						.setPlaceholder('Templates folder path')
+						.setValue(this.plugin.settings.templateFolder)
+						.setDisabled(true); // Make input read-only
+					text.inputEl.style.width = '300px';
+				})
+				.addButton(button => {
+					button
+						.setButtonText('Select')
+						.onClick(() => {
+							new FolderSearchModal(this.app, async (folder: TFolder) => {
+								const chosenPath = folder.path === '/' ? '' : folder.path;
+								this.plugin.settings.templateFolder = chosenPath;
+								await this.plugin.saveSettings();
+								this.display();
+							}).open();
+						});
+				});
+
+			new Setting(containerEl)
+				.setName('Default template')
+				.setDesc('Path to default template (leave empty to show picker each time)')
+				.addText(text => {
+					text
+						.setValue(this.plugin.settings.templatePath)
+						.setDisabled(true); // Make input read-only
+					text.inputEl.style.width = '300px';
+				})
+				.addButton(button => {
+					button
+						.setButtonText('Select')
+						.onClick(() => {
+							new TemplateSearchModal(
+								this.app, 
+								this.plugin.settings.templateFolder,
+								async (file: TFile) => {
+									this.plugin.settings.templatePath = file.path;
+									await this.plugin.saveSettings();
+									this.display();
+								}
+							).open();
+						});
+				})
+				.addButton(button => {
+					button
+						.setButtonText('Clear')
+						.onClick(async () => {
+							this.plugin.settings.templatePath = '';
+							await this.plugin.saveSettings();
+							this.display();
+						});
+				});
+		}
+	}
+}
+
+class TemplateSearchModal extends FuzzySuggestModal<TFile> {
+	onChoose: (file: TFile) => void;
+	templateFolder: string;
+
+	constructor(app: App, templateFolder: string, onChoose: (file: TFile) => void) {
+		super(app);
+		this.templateFolder = templateFolder;
+		this.onChoose = onChoose;
+		this.setPlaceholder('Select a template...');
+	}
+
+	getItems(): TFile[] {
+		const files = this.app.vault.getMarkdownFiles();
+		
+		if (!this.templateFolder) {
+			return files;
+		}
+		
+		return files.filter(file => file.path.startsWith(this.templateFolder));
+	}
+
+	getItemText(file: TFile): string {
+		return file.path;
+	}
+
+	onChooseItem(file: TFile): void {
+		this.onChoose(file);
+	}
+}
+
+class FolderSearchModal extends FuzzySuggestModal<TFolder> {
+	onChoose: (folder: TFolder) => void;
+
+	constructor(app: App, onChoose: (folder: TFolder) => void) {
+		super(app);
+		this.onChoose = onChoose;
+		this.setPlaceholder('Select a folder...');
+	}
+
+	getItems(): TFolder[] {
+		const folders: TFolder[] = [];
+		const rootFolder = this.app.vault.getRoot();
+		
+		const collectFolders = (folder: TFolder): void => {
+			folders.push(folder);
+			for (const child of folder.children) {
+				if (child instanceof TFolder) {
+					collectFolders(child);
+				}
+			}
+		};
+		
+		collectFolders(rootFolder);
+		return folders
+			.filter(f => !f.path.startsWith('.obsidian'))
+			.sort((a, b) => a.path.localeCompare(b.path));
+	}
+
+	getItemText(folder: TFolder): string {
+		return folder.path || '/';
+	}
+
+	onChooseItem(folder: TFolder): void {
+		this.onChoose(folder);
 	}
 }

--- a/src/templateProcessor.ts
+++ b/src/templateProcessor.ts
@@ -1,0 +1,33 @@
+import { moment } from 'obsidian';
+
+export class TemplateProcessor {
+	processTemplateVariables(content: string, projectName: string): string {
+		const now = moment();
+		
+		let processedContent = content;
+		
+		// Core Obsidian Templates plugin compatible variables
+		processedContent = processedContent.replace(/\{\{title\}\}/g, projectName);
+		processedContent = processedContent.replace(/\{\{date\}\}/g, now.format('YYYY-MM-DD'));
+		processedContent = processedContent.replace(/\{\{time\}\}/g, now.format('HH:mm'));
+		
+		// Custom format replacements - directly pass format to moment
+		processedContent = processedContent.replace(/\{\{date:([^}]+)\}\}/g, (match, format) => {
+			try {
+				return now.format(format);
+			} catch {
+				return match;
+			}
+		});
+		
+		processedContent = processedContent.replace(/\{\{time:([^}]+)\}\}/g, (match, format) => {
+			try {
+				return now.format(format);
+			} catch {
+				return match;
+			}
+		});
+		
+		return processedContent;
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,15 @@
 export interface ProjectIndexerSettings {
 	projectIndexFolder: string;
 	frontmatterColumns: string[];
+	useTemplate: boolean;
+	templateFolder: string;
+	templatePath: string;
 }
 
 export const DEFAULT_SETTINGS: ProjectIndexerSettings = {
 	projectIndexFolder: 'projects',
-	frontmatterColumns: ['status', 'priority']
+	frontmatterColumns: ['status', 'priority'],
+	useTemplate: false,
+	templateFolder: 'templates',
+	templatePath: ''
 };


### PR DESCRIPTION
## Summary
- Add template support for creating project index files with custom templates
- Implementation follows the design patterns from template-mint plugin
- Ensures required frontmatter fields are always preserved

## Changes
- ✨ Add template selection UI with folder/file pickers
- ✨ Implement template variable processing (`{{title}}`, `{{date}}`, `{{time}}`, etc.)
- ✅ Ensure required frontmatter (`type: project_top`, `project`) is always set
- 🔒 Use Obsidian API `processFrontMatter` for safe frontmatter manipulation
- ⚙️ Add template configuration options to settings page
- 📝 Update README with template usage documentation

## Implementation Details
### Template Variables
- `{{title}}` - Project name
- `{{date}}` - Current date (YYYY-MM-DD)
- `{{time}}` - Current time (HH:mm)
- `{{date:FORMAT}}` - Custom date format
- `{{time:FORMAT}}` - Custom time format

### Required Frontmatter
The following frontmatter fields are always set regardless of template content:
- `type: project_top`
- `project: [project name]`

## Test plan
- [x] Verify default content is used when no template is configured
- [x] Verify template is applied when configured
- [x] Verify template variables are correctly replaced
- [x] Verify required frontmatter is always set
- [x] TypeScript type checking passes
- [x] ESLint checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added template support for new project index files, including variables like {{title}}, {{date}}, and {{time}} with custom formats.
  * Introduced Template Settings: Use template toggle, Template folder selection, and Default template picker with searchable modals.
  * Automatically sets required frontmatter on new index files (type: project_top and project: [project name]) regardless of template content.

* Documentation
  * Expanded README with Template Settings and Template Variables sections, updated examples to use project_top, and clarified automatic frontmatter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->