### PR TITLE
feat: Add update project index command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Automatically generate and maintain project index notes with customizable frontm
 ## Features
 
 - **Manual Project Index Generation**: Create project index notes with a single command from any note containing a `project` frontmatter field
+- **Update Existing Index**: Update project index tables without recreating the entire file
 - **Customizable Columns**: Configure which frontmatter fields appear as columns in the index table
 - **Organized Structure**: Project index files are created in a designated folder for better organization
 - **Table Management**: Automatically updates existing tables when regenerating the index
@@ -42,6 +43,14 @@ priority: high
 2. Run the command "Create project index from current note" from the Command Palette (Ctrl/Cmd + P)
 
 3. A project index file will be created at `<configured-folder>/MyProject.md` with a table containing all notes in that project
+
+### Updating Project Index
+
+To update an existing project index with the latest notes:
+
+1. Open any note that belongs to the project (has the same `project` field in frontmatter)
+2. Run the command "Update project index for current note" from the Command Palette
+3. The project index table will be refreshed with the current list of project notes
 
 ### Example Output
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -36,6 +36,36 @@ export class ProjectIndexer {
 		}
 	}
 
+	async updateProjectIndexForFile(currentFile: TFile): Promise<void> {
+		try {
+			const metadata = this.app.metadataCache.getFileCache(currentFile);
+			if (!metadata?.frontmatter) {
+				new Notice('Current note has no frontmatter');
+				return;
+			}
+
+			const projectName = metadata.frontmatter.project;
+			if (!projectName) {
+				new Notice('Current note has no "project" field in frontmatter');
+				return;
+			}
+
+			const projectIndexPath = `${this.settings.projectIndexFolder}/${this.toFileName(projectName)}.md`;
+			const projectIndexFile = this.app.vault.getAbstractFileByPath(projectIndexPath);
+			
+			if (!projectIndexFile || !(projectIndexFile instanceof TFile)) {
+				new Notice(`Project index file not found for: ${projectName}. Use "Create project index" command first.`);
+				return;
+			}
+
+			await this.updateProjectIndex(projectIndexFile, projectName);
+			new Notice(`Project index updated for: ${projectName}`);
+		} catch (error) {
+			console.error('Error updating project index:', error);
+			new Notice('Failed to update project index');
+		}
+	}
+
 	private async ensureProjectIndexFile(projectName: string): Promise<TFile> {
 		const folderPath = this.settings.projectIndexFolder;
 		await this.ensureFolderExists(folderPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,17 @@ export default class ProjectIndexerPlugin extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'update-project-index',
+			name: 'Update project index for current note',
+			editorCallback: async (editor, view) => {
+				const file = view.file;
+				if (file) {
+					await this.indexer.updateProjectIndexForFile(file);
+				}
+			}
+		});
+
 		this.addSettingTab(new ProjectIndexerSettingTab(this.app, this));
 	}
 


### PR DESCRIPTION
## Summary
- Add new command to update existing project index files
- Users can now update project indices without recreating the entire file
- Maintain existing content while refreshing the notes table

## Changes
- Added `Update project index for current note` command in main.ts
- Implemented `updateProjectIndexForFile` method in ProjectIndexer class
- Updated README.md with usage instructions

## Test plan
- [x] Create a project with multiple notes
- [x] Generate initial project index using "Create project index from current note"
- [x] Add/remove notes from the project
- [x] Run "Update project index for current note" command
- [x] Verify table is updated while preserving other content

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Update project index for current note” command to refresh a project’s index table without recreating the file. Requires an existing project index and a note with matching project frontmatter.

* **Documentation**
  * Added a “Update Existing Index” feature bullet.
  * Added “Updating Project Index” usage section with steps to run the new command from the Command Palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->