### PR TITLE
feat: Add create notes from templates functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ Automatically generate and maintain project index notes with customizable frontm
 
 - **Manual Project Index Generation**: Create project index notes with a single command from any note containing a `project` frontmatter field
 - **Update Existing Index**: Update project index tables without recreating the entire file
+- **Create Notes from Templates**: Create new notes from templates directly from project_top files with frontmatter inheritance
 - **Customizable Columns**: Configure which frontmatter fields appear as columns in the index table
 - **Organized Structure**: Project index files are created in a designated folder for better organization
 - **Table Management**: Automatically updates existing tables when regenerating the index
 - **Template Support**: Use custom templates for new project index files with variable substitution
+- **Frontmatter Inheritance**: Automatically inherit specified frontmatter fields when creating notes from templates
 
 ## Installation
 
@@ -52,6 +54,18 @@ To update an existing project index with the latest notes:
 2. Run the command "Update project index for current note" from the Command Palette
 3. The project index table will be refreshed with the current list of project notes
 
+### Creating Notes from Templates
+
+To create a new note from a template within a project:
+
+1. Open the project_top file (project index file with `type: project_top` in frontmatter)
+2. Run the command "Create note from template (project top)" from the Command Palette
+3. Select a template from your template folder
+4. Enter a name for the new note
+5. The new note will be created with:
+   - Template content with variables replaced
+   - Inherited frontmatter fields from the project_top file
+
 ### Example Output
 
 The generated project index will look like this:
@@ -81,24 +95,29 @@ Access plugin settings via Settings → Project Indexer
 
 - **Project index folder**: Specify the folder where project index files will be created (default: `projects`)
 - **Frontmatter columns**: Comma-separated list of frontmatter fields to include as table columns (default: `status, priority`)
+- **Inherited frontmatter fields**: Comma-separated list of frontmatter fields to inherit when creating notes from templates (default: `project`)
 
 ### Template Settings
 
 - **Use template**: Enable to use custom templates when creating new project index files
-- **Template folder**: Select the folder containing your template files (optional)
-- **Default template**: Choose a default template file (leave empty to use default content)
+- **Template folder**: Select the folder containing your template files (optional, used for both project index and note creation)
+- **Default template**: Choose a default template file for project index creation (leave empty to use default content)
 
 ### Template Variables
 
 When using templates, the following variables are automatically replaced:
 
-- `{{title}}` - The project name
+- `{{title}}` - The project name (for project index) or note name (for note creation)
+- `{{project}}` - The project name
 - `{{date}}` - Current date (YYYY-MM-DD)
 - `{{time}}` - Current time (HH:mm)
 - `{{date:FORMAT}}` - Custom date format (e.g., `{{date:YYYY/MM/DD}}`)
 - `{{time:FORMAT}}` - Custom time format (e.g., `{{time:HH:mm:ss}}`)
+- Any inherited frontmatter field (e.g., `{{status}}`, `{{priority}}`)
 
-**Note**: The required frontmatter fields (`type: project_top` and `project: [project name]`) are automatically added regardless of template content.
+**Note**: 
+- For project index files: The required frontmatter fields (`type: project_top` and `project: [project name]`) are automatically added regardless of template content.
+- For notes created from templates: The specified inherited frontmatter fields are automatically merged with the template's frontmatter.
 
 ## Development
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -127,7 +127,11 @@ export class ProjectIndexer {
 			const templateFile = this.app.vault.getAbstractFileByPath(this.settings.templatePath);
 			if (templateFile instanceof TFile) {
 				const templateContent = await this.app.vault.read(templateFile);
-				return this.templateProcessor.processTemplateVariables(templateContent, projectName);
+				// Pass project name as title variable for compatibility
+				return this.templateProcessor.processTemplateVariables(templateContent, { 
+					title: projectName,
+					project: projectName 
+				});
 			}
 		}
 		

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,18 @@ import { Plugin } from 'obsidian';
 import { ProjectIndexer } from './indexer';
 import { ProjectIndexerSettingTab } from './settings';
 import { ProjectIndexerSettings, DEFAULT_SETTINGS } from './types';
+import { NoteCreator } from './noteCreator';
 
 export default class ProjectIndexerPlugin extends Plugin {
 	settings: ProjectIndexerSettings;
 	indexer: ProjectIndexer;
+	noteCreator: NoteCreator;
 
 	async onload() {
 		await this.loadSettings();
 		
 		this.indexer = new ProjectIndexer(this.app, this.settings);
+		this.noteCreator = new NoteCreator(this.app, this.settings);
 
 		this.addCommand({
 			id: 'create-project-index',
@@ -34,6 +37,27 @@ export default class ProjectIndexerPlugin extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'create-note-from-template',
+			name: 'Create note from template (project top)',
+			checkCallback: (checking: boolean) => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (activeFile) {
+					const metadata = this.app.metadataCache.getFileCache(activeFile);
+					const isProjectTop = metadata?.frontmatter?.type === 'project_top';
+					
+					if (checking) {
+						return isProjectTop;
+					}
+					
+					if (isProjectTop) {
+						this.noteCreator.createNoteFromProjectTop(activeFile);
+					}
+				}
+				return false;
+			}
+		});
+
 		this.addSettingTab(new ProjectIndexerSettingTab(this.app, this));
 	}
 
@@ -47,5 +71,6 @@ export default class ProjectIndexerPlugin extends Plugin {
 	async saveSettings() {
 		await this.saveData(this.settings);
 		this.indexer = new ProjectIndexer(this.app, this.settings);
+		this.noteCreator = new NoteCreator(this.app, this.settings);
 	}
 }

--- a/src/noteCreator.ts
+++ b/src/noteCreator.ts
@@ -1,0 +1,264 @@
+import { App, TFile, Notice, FuzzySuggestModal, Modal } from 'obsidian';
+import { ProjectIndexerSettings } from './types';
+import { TemplateProcessor } from './templateProcessor';
+
+export class NoteCreator {
+	private app: App;
+	private settings: ProjectIndexerSettings;
+	private templateProcessor: TemplateProcessor;
+
+	constructor(app: App, settings: ProjectIndexerSettings) {
+		this.app = app;
+		this.settings = settings;
+		this.templateProcessor = new TemplateProcessor();
+	}
+
+	async createNoteFromProjectTop(projectTopFile: TFile): Promise<void> {
+		try {
+			// Get project top metadata
+			const metadata = this.app.metadataCache.getFileCache(projectTopFile);
+			if (!metadata?.frontmatter) {
+				new Notice('Project top file has no frontmatter');
+				return;
+			}
+
+			const projectName = metadata.frontmatter.project;
+			if (!projectName) {
+				new Notice('Project top file has no "project" field in frontmatter');
+				return;
+			}
+
+			// Select template
+			const templateFile = await this.selectTemplate();
+			if (!templateFile) {
+				return;
+			}
+
+			// Prompt for file name
+			const fileName = await this.promptForFileName();
+			if (!fileName) {
+				return;
+			}
+
+			// Get template content
+			const templateContent = await this.app.vault.read(templateFile);
+
+			// Prepare variables for template processing
+			const templateVariables: Record<string, string> = {
+				title: fileName,
+				project: projectName
+			};
+			
+			// Add all inherited frontmatter fields as variables
+			for (const field of this.settings.inheritedFrontmatterFields) {
+				if (metadata.frontmatter && metadata.frontmatter[field] !== undefined) {
+					templateVariables[field] = String(metadata.frontmatter[field]);
+				}
+			}
+
+			// Process template variables (like {{title}}, {{date}}, etc.)
+			const processedContent = this.templateProcessor.processTemplateVariables(templateContent, templateVariables);
+
+			// Create new file path
+			const newFilePath = await this.getNewFilePath(fileName);
+
+			// Create new file with processed template content (including its original frontmatter)
+			const newFile = await this.app.vault.create(newFilePath, processedContent);
+
+			// Use Obsidian's processFrontMatter API to merge/inherit frontmatter fields
+			await this.app.fileManager.processFrontMatter(newFile, (frontmatter) => {
+				// Inherit frontmatter fields from project_top
+				for (const field of this.settings.inheritedFrontmatterFields) {
+					if (metadata.frontmatter && metadata.frontmatter[field] !== undefined) {
+						frontmatter[field] = metadata.frontmatter[field];
+					}
+				}
+			});
+
+			// Open the new file
+			await this.app.workspace.getLeaf().openFile(newFile);
+			new Notice(`Created new note from template: ${newFile.name}`);
+		} catch (error) {
+			console.error('Error creating note from template:', error);
+			new Notice('Failed to create note from template');
+		}
+	}
+
+	private async selectTemplate(): Promise<TFile | null> {
+		// Always show template selector for creating notes from project_top
+		// The default template in settings is only for project_top creation itself
+		return new Promise((resolve) => {
+			new TemplateSelector(
+				this.app,
+				this.settings.templateFolder,
+				(file: TFile | null) => {
+					resolve(file);
+				}
+			).open();
+		});
+	}
+
+
+	private async promptForFileName(): Promise<string | null> {
+		return new Promise((resolve) => {
+			new FileNameModal(
+				this.app,
+				(fileName: string | null) => {
+					resolve(fileName);
+				}
+			).open();
+		});
+	}
+
+	private async getNewFilePath(fileName: string): Promise<string> {
+		// Sanitize file name
+		const sanitizedName = fileName.replace(/[\\/:*?"<>|]/g, '-');
+		
+		// Get active file folder or root
+		const activeFile = this.app.workspace.getActiveFile();
+		const folder = activeFile ? activeFile.parent?.path || '' : '';
+		
+		// Add .md extension if not present
+		const fileNameWithExt = sanitizedName.endsWith('.md') ? sanitizedName : `${sanitizedName}.md`;
+		
+		// Create full path
+		const basePath = folder ? `${folder}/${fileNameWithExt}` : fileNameWithExt;
+		
+		// Check if file exists and add number if needed
+		let counter = 1;
+		let finalPath = basePath;
+		while (this.app.vault.getAbstractFileByPath(finalPath)) {
+			const nameWithoutExt = fileNameWithExt.slice(0, -3);
+			finalPath = folder ? `${folder}/${nameWithoutExt} ${counter}.md` : `${nameWithoutExt} ${counter}.md`;
+			counter++;
+		}
+		
+		return finalPath;
+	}
+}
+
+class TemplateSelector extends FuzzySuggestModal<TFile> {
+	private resolveCallback: (file: TFile | null) => void;
+	templateFolder: string;
+	private hasSelected = false;
+
+	constructor(app: App, templateFolder: string, onChoose: (file: TFile | null) => void) {
+		super(app);
+		this.templateFolder = templateFolder;
+		this.resolveCallback = onChoose;
+		this.setPlaceholder('Select a template...');
+	}
+
+	getItems(): TFile[] {
+		const files = this.app.vault.getMarkdownFiles();
+		
+		if (!this.templateFolder || this.templateFolder === '') {
+			return files;
+		}
+		
+		return files.filter(file => file.path.startsWith(this.templateFolder));
+	}
+
+	getItemText(file: TFile): string {
+		return file.path;
+	}
+
+	onChooseItem(file: TFile): void {
+		this.hasSelected = true;
+		this.resolveCallback(file);
+	}
+
+	onClose(): void {
+		// Use setTimeout to ensure onChooseItem has a chance to execute first
+		setTimeout(() => {
+			if (!this.hasSelected) {
+				this.resolveCallback(null);
+			}
+		}, 0);
+	}
+}
+
+class FileNameModal extends Modal {
+	onChoose: (fileName: string | null) => void;
+	private customInputEl: HTMLInputElement;
+
+	constructor(app: App, onChoose: (fileName: string | null) => void) {
+		super(app);
+		this.onChoose = onChoose;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		
+		contentEl.createEl('h3', { text: 'Create new note' });
+		
+		const inputContainer = contentEl.createDiv('input-container');
+		inputContainer.style.marginBottom = '1em';
+		
+		this.customInputEl = inputContainer.createEl('input', {
+			type: 'text',
+			placeholder: 'Enter file name...',
+		});
+		this.customInputEl.style.width = '100%';
+		this.customInputEl.style.padding = '0.5em';
+		
+		// Focus input after a short delay to ensure modal is fully opened
+		setTimeout(() => {
+			this.customInputEl.focus();
+		}, 10);
+		
+		// Handle enter key
+		this.customInputEl.addEventListener('keydown', (e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				this.submitInput();
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				this.onChoose(null);
+				this.close();
+			}
+		});
+		
+		// Create button container
+		const buttonContainer = contentEl.createDiv('modal-button-container');
+		buttonContainer.style.display = 'flex';
+		buttonContainer.style.justifyContent = 'flex-end';
+		buttonContainer.style.gap = '0.5em';
+		
+		// Cancel button
+		const cancelButton = buttonContainer.createEl('button', { text: 'Cancel' });
+		cancelButton.addEventListener('click', () => {
+			this.onChoose(null);
+			this.close();
+		});
+		
+		// Create button
+		const createButton = buttonContainer.createEl('button', { 
+			text: 'Create',
+			cls: 'mod-cta'
+		});
+		createButton.addEventListener('click', () => {
+			this.submitInput();
+		});
+	}
+
+	private submitInput(): void {
+		const value = this.customInputEl.value.trim();
+		if (value) {
+			this.onChoose(value);
+			this.close();
+		} else {
+			// Show error or focus input if empty
+			this.customInputEl.focus();
+			this.customInputEl.style.borderColor = 'var(--text-error)';
+			setTimeout(() => {
+				this.customInputEl.style.borderColor = '';
+			}, 2000);
+		}
+	}
+
+	onClose(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,6 +40,20 @@ export class ProjectIndexerSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
+		new Setting(containerEl)
+			.setName('Inherited frontmatter fields')
+			.setDesc('Comma-separated list of frontmatter fields to inherit when creating notes from templates')
+			.addText(text => text
+				.setPlaceholder('project, status')
+				.setValue(this.plugin.settings.inheritedFrontmatterFields.join(', '))
+				.onChange(async (value) => {
+					this.plugin.settings.inheritedFrontmatterFields = value
+						.split(',')
+						.map(field => field.trim())
+						.filter(field => field.length > 0);
+					await this.plugin.saveSettings();
+				}));
+
 		containerEl.createEl('h3', { text: 'Template Settings' });
 
 		new Setting(containerEl)

--- a/src/templateProcessor.ts
+++ b/src/templateProcessor.ts
@@ -1,13 +1,13 @@
 import { moment } from 'obsidian';
 
 export class TemplateProcessor {
-	processTemplateVariables(content: string, projectName: string): string {
+	processTemplateVariables(content: string, variables: Record<string, string> = {}): string {
 		const now = moment();
 		
 		let processedContent = content;
 		
 		// Core Obsidian Templates plugin compatible variables
-		processedContent = processedContent.replace(/\{\{title\}\}/g, projectName);
+		processedContent = processedContent.replace(/\{\{title\}\}/g, variables.title || '');
 		processedContent = processedContent.replace(/\{\{date\}\}/g, now.format('YYYY-MM-DD'));
 		processedContent = processedContent.replace(/\{\{time\}\}/g, now.format('HH:mm'));
 		
@@ -27,6 +27,12 @@ export class TemplateProcessor {
 				return match;
 			}
 		});
+		
+		// Process any custom variables passed in
+		for (const [key, value] of Object.entries(variables)) {
+			const regex = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+			processedContent = processedContent.replace(regex, value);
+		}
 		
 		return processedContent;
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface ProjectIndexerSettings {
 	useTemplate: boolean;
 	templateFolder: string;
 	templatePath: string;
+	inheritedFrontmatterFields: string[];
 }
 
 export const DEFAULT_SETTINGS: ProjectIndexerSettings = {
@@ -11,5 +12,6 @@ export const DEFAULT_SETTINGS: ProjectIndexerSettings = {
 	frontmatterColumns: ['status', 'priority'],
 	useTemplate: false,
 	templateFolder: 'templates',
-	templatePath: ''
+	templatePath: '',
+	inheritedFrontmatterFields: ['project']
 };


### PR DESCRIPTION
## Summary
- Add ability to create new notes from templates directly from project_top files
- Implement frontmatter inheritance from project_top to newly created notes
- Extend template processing capabilities for better code reuse

## Changes
- ✨ Add new command "Create note from template (project top)" available only on project_top files
- 🎨 Implement NoteCreator class to handle the note creation workflow
- 🔧 Add "Inherited frontmatter fields" setting for configuring which fields to inherit
- ♻️ Extend TemplateProcessor class with shared template processing logic
- 📝 Update README with new feature documentation

## Features
- Template selection modal (always shows, no default template for this feature)
- Custom file name input with validation
- Template variable substitution ({{title}}, {{project}}, {{date}}, etc.)
- Frontmatter inheritance using Obsidian's processFrontMatter API
- Proper error handling and user notifications

## Test Plan
- [x] Create a project_top file with frontmatter including `project` field
- [x] Run "Create note from template (project top)" command
- [x] Select a template from the modal
- [x] Enter a file name for the new note
- [x] Verify the note is created with:
  - Template content with variables replaced
  - Inherited frontmatter fields from project_top
- [x] Test with different template configurations
- [x] Test cancellation at each step

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create notes from templates directly from project-top files, with template selection and custom file naming.
  * Configurable frontmatter inheritance when creating notes; inherited fields are merged into the new note (default: project).
  * Expanded template variables, including {{title}}, {{project}}, and any inherited frontmatter fields.

* **Settings**
  * Added “Inherited frontmatter fields” option to control which fields carry over to new notes.

* **Documentation**
  * New usage guide for creating notes from templates.
  * Updated template settings and variables, and clarified frontmatter inheritance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->